### PR TITLE
Fix issue #25: Node references for three winding transformers

### DIFF
--- a/src/power_grid_model_io/converters/tabular_converter.py
+++ b/src/power_grid_model_io/converters/tabular_converter.py
@@ -24,13 +24,14 @@ from power_grid_model_io.mappings.value_mapping import ValueMapping, Values
 from power_grid_model_io.utils.auto_id import AutoID
 from power_grid_model_io.utils.modules import get_function
 
-COL_REF_RE = re.compile(r"([^!]+)!([^\[]+)\[(([^!]+)!)?([^=]+)=(([^!]+)!)?([^\]]+)\]")
+COL_REF_RE = re.compile(r"^([^!]+)!([^\[]+)\[(([^!]+)!)?([^=]+)=(([^!]+)!)?([^\]]+)\]$")
 r"""
 Regular expressions to match patterns like:
   OtherTable!ValueColumn[IdColumn=RefColumn]
 and:
   OtherTable!ValueColumn[OtherTable!IdColumn=ThisTable!RefColumn]
 
+^           Start of the string
 ([^!]+)     OtherTable
 !           separator
 ([^\[]+)    ValueColumn
@@ -43,6 +44,21 @@ and:
 =           separator
 ([^\]]+)
 ]           separator
+$           End of the string
+"""
+
+NODE_REF_RE = re.compile(r"^(.+_)?node(_.+)?$")
+r"""
+Regular expressions to match the word node with an optional prefix or suffix, e.g.:
+    - node
+    - from_node
+    - node_1
+
+^           Start of the string
+(.+_)?      Optional prefix, ending with an underscore
+node        The word 'node'
+(_.+)?      Optional suffix, starting with in an underscore
+$           End of the string
 """
 
 
@@ -193,12 +209,12 @@ class TabularConverter(BaseConverter[TabularData]):
             attr_data = self._handle_id_column(
                 data=data, table=table, component=component, col_def=col_def, extra_info=extra_info
             )
-        elif attr.endswith("node"):
-            # Atributes that end with "node" are refences to nodes. Currently this is the only type of reference
+        elif NODE_REF_RE.fullmatch(attr):
+            # Attributes that contain "node" are references to nodes. Currently this is the only type of reference
             # that is supported.
             attr_data = self._handle_node_ref_column(data=data, table=table, col_def=col_def)
-        elif attr.endswith("object"):
-            # Atributes that end with "object" can be references to different types of objects, as used by sensors.
+        elif attr == "measured_object":
+            # Attributes that end with "object" can be references to different types of objects, as used by sensors.
             raise NotImplementedError(f"{component}s are not implemented, because of the '{attr}' reference...")
         elif attr == "extra":
             # Extra info must be linked to the object IDs, therefore the uuids should be known before extra info can

--- a/src/power_grid_model_io/converters/tabular_converter.py
+++ b/src/power_grid_model_io/converters/tabular_converter.py
@@ -214,7 +214,7 @@ class TabularConverter(BaseConverter[TabularData]):
             # that is supported.
             attr_data = self._handle_node_ref_column(data=data, table=table, col_def=col_def)
         elif attr == "measured_object":
-            # Attributes that end with "object" can be references to different types of objects, as used by sensors.
+            # The attribute "measured_object" can be a reference to different types of objects, as used by sensors.
             raise NotImplementedError(f"{component}s are not implemented, because of the '{attr}' reference...")
         elif attr == "extra":
             # Extra info must be linked to the object IDs, therefore the uuids should be known before extra info can

--- a/tests/unit/converters/test_tabular_converter.py
+++ b/tests/unit/converters/test_tabular_converter.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 import pytest
 
-from power_grid_model_io.converters.tabular_converter import COL_REF_RE
+from power_grid_model_io.converters.tabular_converter import COL_REF_RE, NODE_REF_RE
 
 
 def ref_cases():
@@ -45,3 +45,18 @@ def test_col_ref_pattern(value: str, groups: Optional[Tuple[Optional[str]]]):
     else:
         assert match is not None
         assert match.groups() == groups
+
+
+def test_node_ref_pattern__pos():
+    assert NODE_REF_RE.fullmatch("node")
+    assert NODE_REF_RE.fullmatch("from_node")
+    assert NODE_REF_RE.fullmatch("to_node")
+    assert NODE_REF_RE.fullmatch("node_1")
+    assert NODE_REF_RE.fullmatch("node_2")
+    assert NODE_REF_RE.fullmatch("node_3")
+
+
+def test_node_ref_pattern__neg():
+    assert not NODE_REF_RE.fullmatch("nodes")
+    assert not NODE_REF_RE.fullmatch("anode")
+    assert not NODE_REF_RE.fullmatch("immunodeficient")


### PR DESCRIPTION
After some discussion with @petersalemink95, we have decided that will keep the automatic node reference mechanism, for simplicity and convenience. So for now we'll abandon my previous suggestion and use this notation instead:
```yaml
node_1: hv_bus
```
I've fixed the issue using a regular expression.