### PR TITLE
TabularData.get_column() returns a reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ power_grid_model_io = ["config/**/*.yaml"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit"]
-addopts = ["--cov=power_grid_model_io", "--cov-report=term", "--cov-report=html:cov_html", "--cov-fail-under=55.34"]
+addopts = ["--cov=power_grid_model_io", "--cov-report=term", "--cov-report=html:cov_html", "--cov-fail-under=55.29"]
 
 [tool.black]
 line-length = 120

--- a/src/power_grid_model_io/data_types/tabular_data.py
+++ b/src/power_grid_model_io/data_types/tabular_data.py
@@ -60,11 +60,6 @@ class TabularData:
         column_data = table_data[column_name]
 
         if isinstance(column_data, np.ndarray):
-            self._log.warning(
-                "Implicitly copying a numpy array and converting it to a pandas DataFrame",
-                table_name=table_name,
-                column_name=column_name,
-            )
             column_data = pd.Series(column_data, name=column_name)
 
         # If unit information is available, convert the unit

--- a/tests/unit/data_types/test_tabular_data.py
+++ b/tests/unit/data_types/test_tabular_data.py
@@ -68,6 +68,18 @@ def test_tabular_data__get_column__numpy(nodes_np: np.ndarray):
     pd.testing.assert_series_equal(col_data, pd.Series([150e3, 10.5e3, 400.0], name="u_rated", dtype=np.float32))
 
 
+def test_tabular_data__get_column__numpy_is_a_reference(nodes_np: np.ndarray):
+    # Arrange
+    data = TabularData(nodes=nodes_np)
+
+    # Act
+    col_data = data.get_column(table_name="nodes", column_name="u_rated")
+    col_data[0] = 123.0  # << should update the source data
+
+    # Assert
+    np.testing.assert_array_equal(nodes_np["u_rated"], np.array([123.0, 10.5e3, 400.0]))
+
+
 def test_tabular_data__get_column__iso(nodes_iso: pd.DataFrame, lines: pd.DataFrame):
     # Arrange
     data = TabularData(nodes=nodes_iso, lines=lines)


### PR DESCRIPTION
Even with numpy arrays source data, the pandas Series returned by get_column() returns a reference.

Note that the coverage has decreased, because some 'tested' code was removed.