### PR TITLE
fix for no vector col in trafo

### DIFF
--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -1565,8 +1565,11 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
             return pd.Series([winding_from, winding_to])
 
         trafo = self.pp_input_data["trafo"]
+        col_names = ["winding_from", "winding_to"]
+        if "vector_group" not in trafo:
+            return pd.DataFrame(np.full(shape=(len(trafo), 2), fill_value=np.nan), columns=col_names)
         trafo = trafo["vector_group"].apply(vector_group_to_winding_types)
-        trafo.columns = ["winding_from", "winding_to"]
+        trafo.columns = col_names
         return trafo
 
     def get_trafo3w_winding_types(self) -> pd.DataFrame:
@@ -1588,8 +1591,11 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
             return pd.Series([winding_1, winding_2, winding_3])
 
         trafo3w = self.pp_input_data["trafo3w"]
+        col_names = ["winding_1", "winding_2", "winding_3"]
+        if "vector_group" not in trafo3w:
+            return pd.DataFrame(np.full(shape=(len(trafo3w), 3), fill_value=np.nan), columns=col_names)
         trafo3w = trafo3w["vector_group"].apply(vector_group_to_winding_types)
-        trafo3w.columns = ["winding_1", "winding_2", "winding_3"]
+        trafo3w.columns = col_names
         return trafo3w
 
     def _get_pp_attr(self, table: str, attribute: str, default: Optional[Union[float, bool, str]] = None) -> np.ndarray:

--- a/tests/unit/converters/test_pandapower_converter_input.py
+++ b/tests/unit/converters/test_pandapower_converter_input.py
@@ -1532,8 +1532,13 @@ def test_get_trafo_winding_types__vector_group(mock_get_winding: MagicMock):
     mock_get_winding.side_effect = [WindingType.delta, WindingType.wye_n, WindingType.wye_n, WindingType.delta]
     expected = pd.DataFrame([(2, 1), (1, 2), (2, 1)], columns=["winding_from", "winding_to"])
 
+    converter_empty = PandaPowerConverter()
+    converter_empty.pp_input_data = {"trafo": pd.DataFrame([1, 2, 3], columns=["id"])}
+    expected_empty = pd.DataFrame(np.full((3, 2), np.nan), columns=["winding_from", "winding_to"])
+
     # Act
     actual = converter.get_trafo_winding_types()
+    actual_empty = converter_empty.get_trafo_winding_types()
 
     # Assert
     pd.testing.assert_frame_equal(actual, expected)
@@ -1542,6 +1547,8 @@ def test_get_trafo_winding_types__vector_group(mock_get_winding: MagicMock):
     assert mock_get_winding.call_args_list[1] == call("yn")
     assert mock_get_winding.call_args_list[2] == call("YN")
     assert mock_get_winding.call_args_list[3] == call("d")
+
+    pd.testing.assert_frame_equal(actual_empty, expected_empty)
 
 
 @patch("power_grid_model_io.converters.pandapower_converter.get_winding")
@@ -1565,8 +1572,13 @@ def test_get_trafo3w_winding_types__vector_group(mock_get_winding: MagicMock):
 
     expected = pd.DataFrame([[2, 1, 3], [1, 2, 0], [2, 1, 0]], columns=["winding_1", "winding_2", "winding_3"])
 
+    converter_empty = PandaPowerConverter()
+    converter_empty.pp_input_data = {"trafo3w": pd.DataFrame([1, 2, 3], columns=["id"])}
+    expected_empty = pd.DataFrame(np.full((3, 3), np.nan), columns=["winding_1", "winding_2", "winding_3"])
+
     # Act
     actual = converter.get_trafo3w_winding_types()
+    actual_empty = converter_empty.get_trafo3w_winding_types()
 
     # Assert
     pd.testing.assert_frame_equal(actual, expected)
@@ -1580,6 +1592,8 @@ def test_get_trafo3w_winding_types__vector_group(mock_get_winding: MagicMock):
     assert mock_get_winding.call_args_list[6] == call("D")
     assert mock_get_winding.call_args_list[7] == call("yn")
     assert mock_get_winding.call_args_list[8] == call("y")
+
+    pd.testing.assert_frame_equal(actual_empty, expected_empty)
 
 
 def test_get_winding_types__value_error():

--- a/tests/unit/converters/test_pandapower_converter_input.py
+++ b/tests/unit/converters/test_pandapower_converter_input.py
@@ -1532,13 +1532,8 @@ def test_get_trafo_winding_types__vector_group(mock_get_winding: MagicMock):
     mock_get_winding.side_effect = [WindingType.delta, WindingType.wye_n, WindingType.wye_n, WindingType.delta]
     expected = pd.DataFrame([(2, 1), (1, 2), (2, 1)], columns=["winding_from", "winding_to"])
 
-    converter_empty = PandaPowerConverter()
-    converter_empty.pp_input_data = {"trafo": pd.DataFrame([1, 2, 3], columns=["id"])}
-    expected_empty = pd.DataFrame(np.full((3, 2), np.nan), columns=["winding_from", "winding_to"])
-
     # Act
     actual = converter.get_trafo_winding_types()
-    actual_empty = converter_empty.get_trafo_winding_types()
 
     # Assert
     pd.testing.assert_frame_equal(actual, expected)
@@ -1548,7 +1543,18 @@ def test_get_trafo_winding_types__vector_group(mock_get_winding: MagicMock):
     assert mock_get_winding.call_args_list[2] == call("YN")
     assert mock_get_winding.call_args_list[3] == call("d")
 
-    pd.testing.assert_frame_equal(actual_empty, expected_empty)
+
+def test_get_trafo_winding_types__vector_group_missing():
+    # Arrange
+    converter = PandaPowerConverter()
+    converter.pp_input_data = {"trafo": pd.DataFrame([1, 2, 3], columns=["id"])}
+    expected = pd.DataFrame(np.full((3, 2), np.nan), columns=["winding_from", "winding_to"])
+
+    # Act
+    actual = converter.get_trafo_winding_types()
+
+    # Assert
+    pd.testing.assert_frame_equal(actual, expected)
 
 
 @patch("power_grid_model_io.converters.pandapower_converter.get_winding")
@@ -1572,13 +1578,8 @@ def test_get_trafo3w_winding_types__vector_group(mock_get_winding: MagicMock):
 
     expected = pd.DataFrame([[2, 1, 3], [1, 2, 0], [2, 1, 0]], columns=["winding_1", "winding_2", "winding_3"])
 
-    converter_empty = PandaPowerConverter()
-    converter_empty.pp_input_data = {"trafo3w": pd.DataFrame([1, 2, 3], columns=["id"])}
-    expected_empty = pd.DataFrame(np.full((3, 3), np.nan), columns=["winding_1", "winding_2", "winding_3"])
-
     # Act
     actual = converter.get_trafo3w_winding_types()
-    actual_empty = converter_empty.get_trafo3w_winding_types()
 
     # Assert
     pd.testing.assert_frame_equal(actual, expected)
@@ -1593,7 +1594,18 @@ def test_get_trafo3w_winding_types__vector_group(mock_get_winding: MagicMock):
     assert mock_get_winding.call_args_list[7] == call("yn")
     assert mock_get_winding.call_args_list[8] == call("y")
 
-    pd.testing.assert_frame_equal(actual_empty, expected_empty)
+
+def test_get_trafo3w_winding_types__vector_group_missing():
+    # Arrange
+    converter = PandaPowerConverter()
+    converter.pp_input_data = {"trafo3w": pd.DataFrame([1, 2, 3], columns=["id"])}
+    expected = pd.DataFrame(np.full((3, 3), np.nan), columns=["winding_1", "winding_2", "winding_3"])
+
+    # Act
+    actual = converter.get_trafo3w_winding_types()
+
+    # Assert
+    pd.testing.assert_frame_equal(actual, expected)
 
 
 def test_get_winding_types__value_error():


### PR DESCRIPTION
the get_winding_types did not have a return empty if not available like in `_get_pp_attr()`. Gives KeyError 
Fixed that.