### PR TITLE
Refactor ExtraInfo type hint

### DIFF
--- a/src/power_grid_model_io/converters/base_converter.py
+++ b/src/power_grid_model_io/converters/base_converter.py
@@ -11,7 +11,7 @@ import structlog
 from power_grid_model.data_types import Dataset, SingleDataset
 
 from power_grid_model_io.data_stores.base_data_store import BaseDataStore
-from power_grid_model_io.data_types import ExtraInfoLookup
+from power_grid_model_io.data_types import ExtraInfo
 from power_grid_model_io.utils.auto_id import AutoID
 
 T = TypeVar("T")
@@ -31,7 +31,7 @@ class BaseConverter(Generic[T], ABC):
 
     def load_input_data(
         self, data: Optional[T] = None, make_extra_info: bool = True
-    ) -> Tuple[SingleDataset, ExtraInfoLookup]:
+    ) -> Tuple[SingleDataset, ExtraInfo]:
         """Load input data and extra info
 
         Note: You shouldn't have to overwrite this method. Check _parse_data() instead.
@@ -44,7 +44,7 @@ class BaseConverter(Generic[T], ABC):
         """
 
         data = self._load_data(data)
-        extra_info: ExtraInfoLookup = {}
+        extra_info: ExtraInfo = {}
         parsed_data = self._parse_data(data=data, data_type="input", extra_info=extra_info if make_extra_info else None)
         if isinstance(parsed_data, list):
             raise TypeError("Input data can not be batch data")
@@ -92,14 +92,14 @@ class BaseConverter(Generic[T], ABC):
         data = self._load_data(data)
         return self._parse_data(data=data, data_type="asym_output", extra_info=None)
 
-    def convert(self, data: Dataset, extra_info: Optional[ExtraInfoLookup] = None) -> T:
+    def convert(self, data: Dataset, extra_info: Optional[ExtraInfo] = None) -> T:
         """Convert input/update/(a)sym_output data and optionally extra info.
 
         Note: You shouldn't have to overwrite this method. Check _serialize_data() instead.
 
         Args:
           data: Dataset:
-          extra_info: Optional[ExtraInfoLookup]:  (Default value = None)
+          extra_info: Optional[ExtraInfo]:  (Default value = None)
 
         Returns:
 
@@ -109,7 +109,7 @@ class BaseConverter(Generic[T], ABC):
     def save(
         self,
         data: Dataset,
-        extra_info: Optional[ExtraInfoLookup] = None,
+        extra_info: Optional[ExtraInfo] = None,
         destination: Optional[BaseDataStore[T]] = None,
     ) -> None:
         """Save input/update/(a)sym_output data and optionally extra info.
@@ -118,7 +118,7 @@ class BaseConverter(Generic[T], ABC):
 
         Args:
           data: Dataset:
-          extra_info: Optional[ExtraInfoLookup]:  (Default value = None)
+          extra_info: Optional[ExtraInfo]:  (Default value = None)
           destination: Optional[BaseDataStore[T]]:  (Default value = None)
 
         Returns:
@@ -140,9 +140,9 @@ class BaseConverter(Generic[T], ABC):
         raise ValueError("No data supplied!")
 
     @abstractmethod  # pragma: nocover
-    def _parse_data(self, data: T, data_type: str, extra_info: Optional[ExtraInfoLookup]) -> Dataset:
+    def _parse_data(self, data: T, data_type: str, extra_info: Optional[ExtraInfo]) -> Dataset:
         pass
 
     @abstractmethod  # pragma: nocover
-    def _serialize_data(self, data: Dataset, extra_info: Optional[ExtraInfoLookup]) -> T:
+    def _serialize_data(self, data: Dataset, extra_info: Optional[ExtraInfo]) -> T:
         pass

--- a/src/power_grid_model_io/converters/pandapower_converter.py
+++ b/src/power_grid_model_io/converters/pandapower_converter.py
@@ -14,7 +14,7 @@ from power_grid_model import Branch3Side, BranchSide, LoadGenType, WindingType, 
 from power_grid_model.data_types import Dataset, SingleDataset
 
 from power_grid_model_io.converters.base_converter import BaseConverter
-from power_grid_model_io.data_types import ExtraInfoLookup
+from power_grid_model_io.data_types import ExtraInfo
 from power_grid_model_io.functions import get_winding
 from power_grid_model_io.utils.regex import NODE_REF_RE, TRAFO3_CONNECTION_RE, TRAFO_CONNECTION_RE
 
@@ -48,9 +48,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         self.idx_lookup: Dict[Tuple[str, Optional[str]], pd.Series] = {}
         self.next_idx = 0
 
-    def _parse_data(
-        self, data: PandaPowerData, data_type: str, extra_info: Optional[ExtraInfoLookup] = None
-    ) -> Dataset:
+    def _parse_data(self, data: PandaPowerData, data_type: str, extra_info: Optional[ExtraInfo] = None) -> Dataset:
         """
         Set up for conversion from PandaPower to power-grid-model
 
@@ -85,7 +83,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
 
         return self.pgm_input_data
 
-    def _serialize_data(self, data: Dataset, extra_info: Optional[ExtraInfoLookup]) -> PandaPowerData:
+    def _serialize_data(self, data: Dataset, extra_info: Optional[ExtraInfo]) -> PandaPowerData:
         """
         Set up for conversion from power-grid-model to PandaPower
 
@@ -137,7 +135,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
         self._create_pgm_input_generators()
         self._create_pgm_input_dclines()
 
-    def _fill_extra_info(self, extra_info: ExtraInfoLookup):
+    def _fill_extra_info(self, extra_info: ExtraInfo):
         for (pp_table, name), indices in self.idx_lookup.items():
             for pgm_id, pp_idx in zip(indices.index, indices):
                 if name:
@@ -153,7 +151,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
                         else:
                             extra_info[pgm_id][attr_name] = node_id
 
-    def _extra_info_to_idx_lookup(self, extra_info: ExtraInfoLookup):
+    def _extra_info_to_idx_lookup(self, extra_info: ExtraInfo):
         """
         Converts extra component info into idx_lookup
 
@@ -179,7 +177,7 @@ class PandaPowerConverter(BaseConverter[PandaPowerData]):
             self.idx[key] = pd.Series(pgm_ids, index=pp_indices)
             self.idx_lookup[key] = pd.Series(pp_indices, index=pgm_ids)
 
-    def _extra_info_to_pgm_input_data(self, extra_info: ExtraInfoLookup):
+    def _extra_info_to_pgm_input_data(self, extra_info: ExtraInfo):
         """
         Converts extra component info into node_lookup
 

--- a/src/power_grid_model_io/converters/pgm_json_converter.py
+++ b/src/power_grid_model_io/converters/pgm_json_converter.py
@@ -19,7 +19,7 @@ from power_grid_model.utils import (
 
 from power_grid_model_io.converters.base_converter import BaseConverter
 from power_grid_model_io.data_stores.json_file_store import JsonFileStore
-from power_grid_model_io.data_types import ExtraInfoLookup, StructuredData
+from power_grid_model_io.data_types import ExtraInfo, StructuredData
 from power_grid_model_io.utils.dict import merge_dicts
 
 
@@ -44,7 +44,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
         destination = JsonFileStore(file_path=Path(destination_file)) if destination_file else None
         super().__init__(source=source, destination=destination)
 
-    def _parse_data(self, data: StructuredData, data_type: str, extra_info: Optional[ExtraInfoLookup]) -> Dataset:
+    def _parse_data(self, data: StructuredData, data_type: str, extra_info: Optional[ExtraInfo]) -> Dataset:
         """This function expects Structured data, which can either be a dictionary (single dataset) or a list of
         dictionaries (batch dataset). The structured dataset consists of components + attributes that exist within
         power-grid-model, but can also contain other data. If this data should be saved for later usage an extra_info
@@ -57,7 +57,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
         power-grid-model data) can be specified
           data: StructuredData:
           data_type: str:
-          extra_info: Optional[ExtraInfoLookup]:
+          extra_info: Optional[ExtraInfo]:
 
         Returns:
           a dictionary containing the components as keys and their corresponding numpy arrays as values: a
@@ -75,7 +75,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
         return self._parse_dataset(data=data, data_type=data_type, extra_info=extra_info)
 
     def _parse_dataset(
-        self, data: SinglePythonDataset, data_type: str, extra_info: Optional[ExtraInfoLookup]
+        self, data: SinglePythonDataset, data_type: str, extra_info: Optional[ExtraInfo]
     ) -> SingleDataset:
         """This function parses a single Python dataset and returns a power-grid-model input or update dictionary
 
@@ -86,7 +86,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
         power-grid-model data) can be specified
           data: SinglePythonDataset:
           data_type: str:
-          extra_info: Optional[ExtraInfoLookup]:  (Default value = None)
+          extra_info: Optional[ExtraInfo]:  (Default value = None)
 
         Returns:
           a dictionary containing the components as keys and their corresponding numpy arrays as values: a
@@ -102,7 +102,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
 
     @staticmethod
     def _parse_component(
-        objects: ComponentList, component: str, data_type: str, extra_info: Optional[ExtraInfoLookup]
+        objects: ComponentList, component: str, data_type: str, extra_info: Optional[ExtraInfo]
     ) -> np.ndarray:
         """This function generates a structured numpy array (power-grid-model native) from a structured dataset
 
@@ -116,7 +116,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
           objects: ComponentList:
           component: str:
           data_type: str:
-          extra_info: Optional[ExtraInfoLookup]:  (Default value = None)
+          extra_info: Optional[ExtraInfo]:  (Default value = None)
 
         Returns:
           a numpy structured array for a power-grid-model component
@@ -144,7 +144,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
                     extra_info[obj["id"]][attribute] = value
         return array
 
-    def _serialize_data(self, data: Dataset, extra_info: Optional[ExtraInfoLookup]) -> StructuredData:
+    def _serialize_data(self, data: Dataset, extra_info: Optional[ExtraInfo]) -> StructuredData:
         """This function converts a power-grid-model dataset to a structured dataset. First, the function checks if the
         dataset is a single dataset or batch dataset. If it is a batch, the batch data is converted to a list of
         batches, then each batch is converted individually.
@@ -155,7 +155,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
         structured dataset. The keys in this dictionary should match with id's of components in the power-grid-model
         dataset. Note, extra info can only be supplied for single datasets
           data: Dataset:
-          extra_info: Optional[ExtraInfoLookup]:  (Default value = None)
+          extra_info: Optional[ExtraInfo]:  (Default value = None)
 
         Returns:
           the function returns a structured dataset
@@ -206,7 +206,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
         return bool(is_batch)
 
     @staticmethod
-    def _serialize_dataset(data: SingleDataset, extra_info: Optional[ExtraInfoLookup] = None) -> SinglePythonDataset:
+    def _serialize_dataset(data: SingleDataset, extra_info: Optional[ExtraInfo] = None) -> SinglePythonDataset:
         """This function converts a single power-grid-model dataset to a structured dataset
 
         Args:
@@ -215,7 +215,7 @@ class PgmJsonConverter(BaseConverter[StructuredData]):
         structured dataset. The keys in this dictionary should match with id's of components in the power-grid-model
         dataset
           data: SingleDataset:
-          extra_info: Optional[ExtraInfoLookup]:  (Default value = None)
+          extra_info: Optional[ExtraInfo]:  (Default value = None)
 
         Returns:
           the function returns a structured dataset

--- a/src/power_grid_model_io/converters/tabular_converter.py
+++ b/src/power_grid_model_io/converters/tabular_converter.py
@@ -16,7 +16,7 @@ from power_grid_model.data_types import Dataset
 
 from power_grid_model_io.converters.base_converter import BaseConverter
 from power_grid_model_io.data_stores.base_data_store import BaseDataStore
-from power_grid_model_io.data_types import ExtraInfoLookup, TabularData
+from power_grid_model_io.data_types import ExtraInfo, TabularData
 from power_grid_model_io.mappings.multiplier_mapping import MultiplierMapping, Multipliers
 from power_grid_model_io.mappings.tabular_mapping import InstanceAttributes, Tables, TabularMapping
 from power_grid_model_io.mappings.unit_mapping import UnitMapping, Units
@@ -79,7 +79,7 @@ class TabularConverter(BaseConverter[TabularData]):
             MultiplierMapping(cast(Multipliers, mapping["multipliers"])) if "multipliers" in mapping else None
         )
 
-    def _parse_data(self, data: TabularData, data_type: str, extra_info: Optional[ExtraInfoLookup]) -> Dataset:
+    def _parse_data(self, data: TabularData, data_type: str, extra_info: Optional[ExtraInfo]) -> Dataset:
         """This function parses tabular data and returns power-grid-model data
 
         Args:
@@ -90,7 +90,7 @@ class TabularConverter(BaseConverter[TabularData]):
         power-grid-model data) can be specified
           data: TabularData:
           data_type: str:
-          extra_info: Optional[ExtraInfoLookup]:
+          extra_info: Optional[ExtraInfo]:
 
         Returns:
           a power-grid-model dataset, i.e. a dictionary as {component: np.ndarray}
@@ -140,7 +140,7 @@ class TabularConverter(BaseConverter[TabularData]):
         table: str,
         component: str,
         attributes: InstanceAttributes,
-        extra_info: Optional[ExtraInfoLookup],
+        extra_info: Optional[ExtraInfo],
     ) -> Optional[np.ndarray]:
         """
         This function converts a single table/sheet of TabularData to a power-grid-model input/update array. One table
@@ -160,7 +160,7 @@ class TabularConverter(BaseConverter[TabularData]):
           table: str:
           component: str:
           attributes: InstanceAttributes:
-          extra_info: Optional[ExtraInfoLookup]:
+          extra_info: Optional[ExtraInfo]:
 
         Returns:
           returns a power-grid-model structured array for one component
@@ -204,7 +204,7 @@ class TabularConverter(BaseConverter[TabularData]):
         component: str,
         attr: str,
         col_def: Any,
-        extra_info: Optional[ExtraInfoLookup],
+        extra_info: Optional[ExtraInfo],
     ):
         """This function updates one of the attributes of pgm_data, based on the corresponding table/column in a tabular
         dataset
@@ -225,7 +225,7 @@ class TabularConverter(BaseConverter[TabularData]):
           component: str:
           attr: str:
           col_def: Any:
-          extra_info: Optional[ExtraInfoLookup]:
+          extra_info: Optional[ExtraInfo]:
 
         Returns:
           the function updates pgm_data, it should not return something
@@ -259,7 +259,7 @@ class TabularConverter(BaseConverter[TabularData]):
         table: str,
         col_def: Any,
         uuids: np.ndarray,
-        extra_info: Optional[ExtraInfoLookup],
+        extra_info: Optional[ExtraInfo],
     ) -> None:
         """This function can extract extra info from the tabular data and store it in the extra_info dict
 
@@ -275,7 +275,7 @@ class TabularConverter(BaseConverter[TabularData]):
           table: str:
           col_def: Any:
           uuids: np.ndarray:
-          extra_info: Optional[ExtraInfoLookup]:
+          extra_info: Optional[ExtraInfo]:
 
         Returns:
 
@@ -322,7 +322,7 @@ class TabularConverter(BaseConverter[TabularData]):
 
         return merged
 
-    def _serialize_data(self, data: Dataset, extra_info: Optional[ExtraInfoLookup]) -> TabularData:
+    def _serialize_data(self, data: Dataset, extra_info: Optional[ExtraInfo]) -> TabularData:
         if extra_info is not None:
             raise NotImplementedError("Extra info can not (yet) be stored for tabular data")
         if isinstance(data, list):
@@ -330,7 +330,7 @@ class TabularConverter(BaseConverter[TabularData]):
         return TabularData(**data)
 
     def _parse_col_def(
-        self, data: TabularData, table: str, col_def: Any, extra_info: Optional[ExtraInfoLookup]
+        self, data: TabularData, table: str, col_def: Any, extra_info: Optional[ExtraInfo]
     ) -> pd.DataFrame:
         """Interpret the column definition and extract/convert/create the data as a pandas DataFrame.
 
@@ -338,7 +338,7 @@ class TabularConverter(BaseConverter[TabularData]):
           data: TabularData:
           table: str:
           col_def: Any:
-          extra_info: Optional[ExtraInfoLookup]:
+          extra_info: Optional[ExtraInfo]:
 
         Returns:
 
@@ -436,7 +436,7 @@ class TabularConverter(BaseConverter[TabularData]):
         return result[[value_column]]
 
     def _parse_col_def_filter(
-        self, data: TabularData, table: str, col_def: Dict[str, Any], extra_info: Optional[ExtraInfoLookup]
+        self, data: TabularData, table: str, col_def: Dict[str, Any], extra_info: Optional[ExtraInfo]
     ) -> pd.DataFrame:
         """
         Parse column filters like 'auto_id', 'reference', 'function', etc
@@ -493,7 +493,7 @@ class TabularConverter(BaseConverter[TabularData]):
         ref_table: Optional[str],
         ref_name: Optional[str],
         key_col_def: Union[str, List[str], Dict[str, str]],
-        extra_info: Optional[ExtraInfoLookup],
+        extra_info: Optional[ExtraInfo],
     ) -> pd.DataFrame:
         """
         Create (or retrieve) a unique numerical id for each object (row) in `data[table]`, based on the `name`

--- a/src/power_grid_model_io/data_types/_data_types.py
+++ b/src/power_grid_model_io/data_types/_data_types.py
@@ -7,32 +7,35 @@ Common data types used in the Power Grid Model project
 
 from typing import Any, Dict, List, Union
 
-from power_grid_model.data_types import AttributeValue
-
-ExtraInfoType = Union[str, AttributeValue, List["ExtraInfoType"], Dict[str, "ExtraInfoType"]]
-ExtraInfo = Dict[str, ExtraInfoType]
+ExtraInfo = Dict[int, Any]
 """
 ExtraInfo is information about power grid model objects that are not part of the calculations. E.g. the original ID or
-name of a node, or the material of a cable (line) etc. Extra info should be a dictionary with textual keys. The
-values may be numerical or textual. Nested structures are also allowed (i.e. dictionaries and lists of numerical or
-textual values, etc etc).
+name of a node, or the material of a cable (line) etc.
+
+It is a dictionary with numerical keys corresponding to the ids in input_data etc. The values are dictionaries with
+textual keys. Their values may be anything, but it is advised to use only JSON serializable types like numerical values,
+strings, lists, dictionaries etc.
 
     {
-        "id": 123,
-        "length_km": 123.4,
-        "material": "Aluminuminuminum",
-        "auto_id": {
-            "name": ["Transformers", "internal_node"],
-            "key": {"Node.Number": 1, "Subnumber": 2}
+        1: {
+            "length_km": 123.4,
+            "material": "Aluminuminuminum",
+        },
+        2: {
+            "id_reference": {
+                "table": "load",
+                "name": "const_power",
+                "index": 101
+            }
         }
     }
 """
 
-ExtraInfoLookup = Dict[int, ExtraInfo]
+ExtraInfoLookup = ExtraInfo
 """
-An ExtraInfoLookup is a dictionary with numerical keys corresponding to the ids in input_data etc. The values are
-ExtraInfo dictionaries.
+Legacy type name; use ExtraInfo instead!
 """
+
 
 StructuredData = Union[Dict[str, List[Dict[str, Any]]], List[Dict[str, List[Dict[str, Any]]]]]
 """

--- a/src/power_grid_model_io/data_types/_data_types.py
+++ b/src/power_grid_model_io/data_types/_data_types.py
@@ -36,7 +36,6 @@ ExtraInfoLookup = ExtraInfo
 Legacy type name; use ExtraInfo instead!
 """
 
-
 StructuredData = Union[Dict[str, List[Dict[str, Any]]], List[Dict[str, List[Dict[str, Any]]]]]
 """
 Structured data is a multi dimensional structure (component_type -> objects -> attribute -> value) or a list of those

--- a/tests/unit/converters/test_pgm_json_converter.py
+++ b/tests/unit/converters/test_pgm_json_converter.py
@@ -9,7 +9,7 @@ from power_grid_model.data_types import BatchDataset, SingleDataset
 from structlog.testing import capture_logs
 
 from power_grid_model_io.converters.pgm_json_converter import PgmJsonConverter
-from power_grid_model_io.data_types import ExtraInfoLookup
+from power_grid_model_io.data_types import ExtraInfo
 
 from ...utils import assert_log_match
 
@@ -64,7 +64,7 @@ def test_parse_data(converter: PgmJsonConverter, structured_input_data, structur
         converter._parse_data(data="str", data_type="input", extra_info=None)  # type: ignore
 
     # test for input dataset
-    extra_info: ExtraInfoLookup = {}
+    extra_info: ExtraInfo = {}
     pgm_data = converter._parse_data(data=structured_input_data, data_type="input", extra_info=extra_info)
     assert len(pgm_data) == 1
     assert len(pgm_data["node"]) == 2
@@ -81,7 +81,7 @@ def test_parse_data(converter: PgmJsonConverter, structured_input_data, structur
 
 
 def test_parse_dataset(converter: PgmJsonConverter, structured_input_data):
-    extra_info: ExtraInfoLookup = {}
+    extra_info: ExtraInfo = {}
     pgm_data = converter._parse_dataset(data=structured_input_data, data_type="input", extra_info=extra_info)
 
     assert len(pgm_data) == 1
@@ -94,7 +94,7 @@ def test_parse_dataset(converter: PgmJsonConverter, structured_input_data):
 def test_parse_component(converter: PgmJsonConverter, structured_input_data):
     objects = list(structured_input_data.values())
     component = "node"
-    extra_info: ExtraInfoLookup = {}
+    extra_info: ExtraInfo = {}
 
     node_array = converter._parse_component(
         objects=objects[0], component=component, data_type="input", extra_info=extra_info
@@ -148,6 +148,6 @@ def test_serialize_dataset(converter: PgmJsonConverter, pgm_input_data: SingleDa
     structured_data = converter._serialize_dataset(data=pgm_input_data, extra_info=None)
     assert structured_data == {"node": [{"id": 1}, {"id": 2}]}
 
-    extra_info: ExtraInfoLookup = {1: {"dummy": "data"}}
+    extra_info: ExtraInfo = {1: {"dummy": "data"}}
     structured_data_with_extra_info = converter._serialize_dataset(data=pgm_input_data, extra_info=extra_info)
     assert structured_data_with_extra_info == {"node": [{"id": 1, "dummy": "data"}, {"id": 2}]}

--- a/tests/unit/converters/test_tabular_converter.py
+++ b/tests/unit/converters/test_tabular_converter.py
@@ -13,7 +13,7 @@ from power_grid_model import initialize_array, power_grid_meta_data
 from power_grid_model.data_types import SingleDataset
 
 from power_grid_model_io.converters.tabular_converter import TabularConverter
-from power_grid_model_io.data_types import ExtraInfoLookup, TabularData
+from power_grid_model_io.data_types import ExtraInfo, TabularData
 from power_grid_model_io.mappings.tabular_mapping import InstanceAttributes
 from power_grid_model_io.mappings.unit_mapping import UnitMapping
 
@@ -221,7 +221,7 @@ def test_handle_extra_info(converter: TabularConverter, tabular_data_no_units_no
         data=tabular_data_no_units_no_substitutions, table="nodes", col_def="u_nom", uuids=uuids, extra_info=None
     )
     # _handle_extra_info creates extra info entry for id's that don't exist and updates existing entries
-    extra_info: ExtraInfoLookup = {0: {"some_value": "some_key"}}
+    extra_info: ExtraInfo = {0: {"some_value": "some_key"}}
     converter._handle_extra_info(
         data=tabular_data_no_units_no_substitutions, table="nodes", col_def="u_nom", uuids=uuids, extra_info=extra_info
     )
@@ -234,7 +234,7 @@ def test_handle_extra_info(converter: TabularConverter, tabular_data_no_units_no
 def test_handle_extra_info__units(converter: TabularConverter, tabular_data: TabularData):
     # Arrange
     uuids = np.array([0, 1])
-    extra_info: ExtraInfoLookup = {}
+    extra_info: ExtraInfo = {}
     tabular_data._units = UnitMapping({"V": {"kV": 1000.0}})
 
     # Act
@@ -559,7 +559,7 @@ def test_parse_auto_id__extra_info(
 ):
     # ref_table: None, ref_name: None, key_col_def: str, extra_info: dict
     mock_get_id.side_effect = [101, 102]
-    extra_info: ExtraInfoLookup = {}
+    extra_info: ExtraInfo = {}
     converter._parse_auto_id(
         data=tabular_data_no_units_no_substitutions,
         table="nodes",
@@ -581,7 +581,7 @@ def test_parse_auto_id__reference_column(
 ):
     # ref_table: str, ref_name: None, key_col_def: dict, extra_info: dict
     mock_get_id.side_effect = [101, 102]
-    extra_info: ExtraInfoLookup = {}
+    extra_info: ExtraInfo = {}
     converter._parse_auto_id(
         data=tabular_data_no_units_no_substitutions,
         table="lines",
@@ -602,7 +602,7 @@ def test_parse_auto_id__composite_key(
 ):
     # ref_table: None, ref_name: None, key_col_def: list, extra_info: dict
     mock_get_id.side_effect = [101, 102]
-    extra_info: ExtraInfoLookup = {}
+    extra_info: ExtraInfo = {}
     converter._parse_auto_id(
         data=tabular_data_no_units_no_substitutions,
         table="nodes",
@@ -627,7 +627,7 @@ def test_parse_auto_id__named_objects(
 ):
     # ref_table: None, ref_name: str, key_col_def: str, extra_info: dict
     mock_get_id.side_effect = [101, 102]
-    extra_info: ExtraInfoLookup = {}
+    extra_info: ExtraInfo = {}
     converter._parse_auto_id(
         data=tabular_data_no_units_no_substitutions,
         table="nodes",
@@ -652,7 +652,7 @@ def test_parse_auto_id__named_keys(
 ):
     # name: str, key_col_def: Dict[str, str], extra_info: dict
     mock_get_id.side_effect = [101, 102]
-    extra_info: ExtraInfoLookup = {}
+    extra_info: ExtraInfo = {}
     converter._parse_auto_id(
         data=tabular_data_no_units_no_substitutions,
         table="lines",

--- a/tests/unit/data_types/test_data_types.py
+++ b/tests/unit/data_types/test_data_types.py
@@ -4,26 +4,14 @@
 
 from pydantic import parse_obj_as
 
-from power_grid_model_io.data_types import ExtraInfo, ExtraInfoLookup, StructuredData
+from power_grid_model_io.data_types import ExtraInfo, StructuredData
 
 
 def test_extra_info():
-    extra_info = {
-        "a": 123,  # NominalValue = int
-        "b": 1.23,  # RealValue = float
-        "c": (1.2, 3.4, 5.6),  # AsymValue = Tuple[float, float, float]
-        "d": "foo",  # str
-    }
+    extra_info = {1: {"a": 123, "b": 1.23}, 2: {"c": (1.2, 3.4, 5.6), "d": "foo"}}
 
     # Expect no exception
     parse_obj_as(ExtraInfo, extra_info)
-
-
-def test_extra_info_lookup():
-    extra_info_lookup = {1: {"a": 123, "b": 1.23}, 2: {"c": (1.2, 3.4, 5.6), "d": "foo"}}
-
-    # Expect no exception
-    parse_obj_as(ExtraInfoLookup, extra_info_lookup)
 
 
 def test_structured_data__single():

--- a/tests/validation/converters/test_pandapower_converter_input.py
+++ b/tests/validation/converters/test_pandapower_converter_input.py
@@ -12,7 +12,7 @@ import pytest
 from power_grid_model.data_types import SingleDataset
 
 from power_grid_model_io.converters import PandaPowerConverter
-from power_grid_model_io.data_types import ExtraInfoLookup
+from power_grid_model_io.data_types import ExtraInfo
 from power_grid_model_io.utils.json import JsonEncoder
 
 from ...data.pandapower.pp_validation import pp_net
@@ -22,7 +22,7 @@ VALIDATION_FILE = Path(__file__).parents[2] / "data" / "pandapower" / "pgm_input
 
 
 @lru_cache
-def load_and_convert_pp_data() -> Tuple[SingleDataset, ExtraInfoLookup]:
+def load_and_convert_pp_data() -> Tuple[SingleDataset, ExtraInfo]:
     """
     Load and convert the pandapower validation network
     """
@@ -33,7 +33,7 @@ def load_and_convert_pp_data() -> Tuple[SingleDataset, ExtraInfoLookup]:
 
 
 @lru_cache
-def load_validation_data() -> Tuple[SingleDataset, ExtraInfoLookup]:
+def load_validation_data() -> Tuple[SingleDataset, ExtraInfo]:
     """
     Load the validation data from the json file
     """
@@ -52,7 +52,7 @@ def input_data() -> Tuple[SingleDataset, SingleDataset]:
 
 
 @pytest.fixture
-def extra_info() -> Tuple[ExtraInfoLookup, ExtraInfoLookup]:
+def extra_info() -> Tuple[ExtraInfo, ExtraInfo]:
     """
     Load the pandapower network and the json file, and return the extra_info
     """
@@ -91,7 +91,7 @@ def test_attributes(input_data: Tuple[SingleDataset, SingleDataset], component: 
     ("component", "obj_ids"),
     (pytest.param(component, objects, id=component) for component, objects in component_objects(VALIDATION_FILE)),
 )
-def test_extra_info(extra_info: Tuple[ExtraInfoLookup, ExtraInfoLookup], component: str, obj_ids: List[int]):
+def test_extra_info(extra_info: Tuple[ExtraInfo, ExtraInfo], component: str, obj_ids: List[int]):
     """
     For each object, check if the actual extra info is consistent with the expected extra info
     """

--- a/tests/validation/converters/test_vision_excel_converter.py
+++ b/tests/validation/converters/test_vision_excel_converter.py
@@ -12,7 +12,7 @@ import pytest
 from power_grid_model.data_types import SingleDataset
 
 from power_grid_model_io.converters import VisionExcelConverter
-from power_grid_model_io.data_types import ExtraInfoLookup
+from power_grid_model_io.data_types import ExtraInfo
 from power_grid_model_io.utils.json import JsonEncoder
 
 from ..utils import compare_extra_info, component_attributes, component_objects, load_json_single_dataset, select_values
@@ -25,7 +25,7 @@ VALIDATION_EN = Path(str(VALIDATION_FILE).format(language="en"))
 
 
 @lru_cache
-def load_and_convert_excel_file(language: str) -> Tuple[SingleDataset, ExtraInfoLookup]:
+def load_and_convert_excel_file(language: str) -> Tuple[SingleDataset, ExtraInfo]:
     """
     Read the excel file and do the conversion
     """
@@ -35,7 +35,7 @@ def load_and_convert_excel_file(language: str) -> Tuple[SingleDataset, ExtraInfo
 
 
 @lru_cache
-def load_validation_data(language: str) -> Tuple[SingleDataset, ExtraInfoLookup]:
+def load_validation_data(language: str) -> Tuple[SingleDataset, ExtraInfo]:
     """
     Load the validation data from the json file
     """
@@ -55,7 +55,7 @@ def input_data(request) -> Tuple[SingleDataset, SingleDataset]:
 
 
 @pytest.fixture
-def extra_info(request) -> Tuple[ExtraInfoLookup, ExtraInfoLookup]:
+def extra_info(request) -> Tuple[ExtraInfo, ExtraInfo]:
     """
     Read the excel file and the json file, and return the extra_info
     """
@@ -96,7 +96,7 @@ def test_attributes(input_data: Tuple[SingleDataset, SingleDataset], component: 
     (pytest.param(component, objects, id=component) for component, objects in component_objects(VALIDATION_EN)),
 )
 @pytest.mark.parametrize("extra_info", LANGUAGES, indirect=True)
-def test_extra_info(extra_info: Tuple[ExtraInfoLookup, ExtraInfoLookup], component: str, obj_ids: List[int]):
+def test_extra_info(extra_info: Tuple[ExtraInfo, ExtraInfo], component: str, obj_ids: List[int]):
     """
     For each object, check if the actual extra info is consistent with the expected extra info
     """

--- a/tests/validation/utils.py
+++ b/tests/validation/utils.py
@@ -13,7 +13,7 @@ from power_grid_model import power_grid_meta_data
 from power_grid_model.data_types import SingleDataset, SinglePythonDataset
 from power_grid_model.utils import convert_python_single_dataset_to_single_dataset
 
-from power_grid_model_io.data_types import ExtraInfoLookup, StructuredData
+from power_grid_model_io.data_types import ExtraInfo, StructuredData
 
 
 @lru_cache()
@@ -137,7 +137,7 @@ def select_values(actual: SingleDataset, expected: SingleDataset, component: str
     return actual_values, expected_values
 
 
-def extract_extra_info(data: SinglePythonDataset, data_type: str) -> ExtraInfoLookup:
+def extract_extra_info(data: SinglePythonDataset, data_type: str) -> ExtraInfo:
     """
     Reads the dataset and collect all arguments that aren't pgm attributes
 
@@ -147,7 +147,7 @@ def extract_extra_info(data: SinglePythonDataset, data_type: str) -> ExtraInfoLo
 
     Returns: A dictionary indexed on the object id and containing the extra info for all the objects.
     """
-    extra_info: ExtraInfoLookup = {}
+    extra_info: ExtraInfo = {}
     for component, objects in data.items():
         pgm_attr = set(power_grid_meta_data[data_type][component].dtype.names)
         for obj in objects:
@@ -157,7 +157,7 @@ def extract_extra_info(data: SinglePythonDataset, data_type: str) -> ExtraInfoLo
     return extra_info
 
 
-def load_json_single_dataset(file_path: Path, data_type: str) -> Tuple[SingleDataset, ExtraInfoLookup]:
+def load_json_single_dataset(file_path: Path, data_type: str) -> Tuple[SingleDataset, ExtraInfo]:
     """
     Loads and parses a json file in the most basic way, without using power_grid_model_io functions.
 
@@ -175,7 +175,7 @@ def load_json_single_dataset(file_path: Path, data_type: str) -> Tuple[SingleDat
     return dataset, extra_info
 
 
-def compare_extra_info(actual: ExtraInfoLookup, expected: ExtraInfoLookup, component: str, obj_ids: List[int]):
+def compare_extra_info(actual: ExtraInfo, expected: ExtraInfo, component: str, obj_ids: List[int]):
     # We'll collect all errors, instead of terminating at the first error
     errors = []
 


### PR DESCRIPTION
- Remove the ExtraInfo type, because it was only used to define ExtraInfoLookup
- Rename ExtraInfoLookup to ExtraInfo, because it is shorter
- Relax the definition to Dict[int, Dict[str, Any]]