### PR TITLE
fix asym values validate in pp

### DIFF
--- a/tests/data/pandapower/pgm_input_data.json
+++ b/tests/data/pandapower/pgm_input_data.json
@@ -49,10 +49,10 @@
     ],
   "asym_load":
     [
-      {"id": 16, "node": 4, "status": 1, "type": 0, "id_reference": {"table": "asymmetric_load", "index": 33}}
+      {"id": 16, "node": 4, "status": 1, "type": 0, "p_specified": [100000.0, 200000.0, 3000000.0], "q_specified": [10000.0, 10000.0, 10000.0], "id_reference": {"table": "asymmetric_load", "index": 33}}
     ],
   "asym_gen":
     [
-      {"id": 17, "node": 4, "status": 1, "type": 0, "id_reference": {"table": "asymmetric_sgen", "index": 32}}
+      {"id": 17, "node": 4, "status": 1, "type": 0, "p_specified": [100000.0, 200000.0, 3000000.0], "q_specified": [10000.0, 10000.0, 10000.0], "id_reference": {"table": "asymmetric_sgen", "index": 32}}
     ]
 }

--- a/tests/validation/converters/test_pandapower_converter_input.py
+++ b/tests/validation/converters/test_pandapower_converter_input.py
@@ -84,7 +84,10 @@ def test_attributes(input_data: Tuple[SingleDataset, SingleDataset], component: 
     actual_values, expected_values = select_values(actual_data, expected_data, component, attribute)
 
     # Assert
-    pd.testing.assert_series_equal(actual_values, expected_values)
+    if isinstance(actual_values, pd.Series) and isinstance(expected_values, pd.Series):
+        pd.testing.assert_series_equal(actual_values, expected_values)
+    else:
+        pd.testing.assert_frame_equal(actual_values, expected_values)
 
 
 @pytest.mark.parametrize(

--- a/tests/validation/utils.py
+++ b/tests/validation/utils.py
@@ -114,12 +114,15 @@ def select_values(actual: SingleDataset, expected: SingleDataset, component: str
     assert attribute in expected[component].dtype.names
 
     # Create an index series for both the actual data and the expected data
-    actual_values = pd.Series(actual[component][attribute], index=actual[component]["id"]).sort_index()
-    expected_values = pd.Series(expected[component][attribute], index=expected[component]["id"]).sort_index()
+    actual_attr = actual[component][attribute]
+    expected_attr = expected[component][attribute]
+    pd_data_fn = pd.DataFrame if actual_attr.ndim == expected_attr.ndim == 2 else pd.Series
+    actual_values = pd_data_fn(actual_attr, index=actual[component]["id"]).sort_index()
+    expected_values = pd_data_fn(expected_attr, index=expected[component]["id"]).sort_index()
 
     # Create a selection mask, to select only non-NaN values in the validation file
-    if np.issubdtype(expected_values.dtype, np.integer):
-        mask = expected_values != np.iinfo(expected_values.dtype).min
+    if np.issubdtype(expected_values.values.dtype, np.integer):
+        mask = expected_values != np.iinfo(expected_values.values.dtype).min
     else:
         mask = ~pd.isna(expected_values)
 
@@ -130,7 +133,7 @@ def select_values(actual: SingleDataset, expected: SingleDataset, component: str
     elif len(missing_idx) > 1:
         raise KeyError(f"Expected {component}s {missing_idx}, but they are missing {actual_values.index.tolist()}.")
 
-    actual_values = actual_values[expected_values.index][mask]
+    actual_values = actual_values.loc[expected_values.index][mask]
     expected_values = expected_values[mask]
 
     # Return the result

--- a/tests/validation/utils.py
+++ b/tests/validation/utils.py
@@ -116,7 +116,8 @@ def select_values(actual: SingleDataset, expected: SingleDataset, component: str
     # Create an index series for both the actual data and the expected data
     actual_attr = actual[component][attribute]
     expected_attr = expected[component][attribute]
-    pd_data_fn = pd.DataFrame if actual_attr.ndim == expected_attr.ndim == 2 else pd.Series
+    assert actual_attr.ndim == expected_attr.ndim in [1, 2]
+    pd_data_fn = pd.DataFrame if actual_attr.ndim == 2 else pd.Series
     actual_values = pd_data_fn(actual_attr, index=actual[component]["id"]).sort_index()
     expected_values = pd_data_fn(expected_attr, index=expected[component]["id"]).sort_index()
 


### PR DESCRIPTION
Asymmetric values in input validation cannot not be validated because they are expected to be a singular value. Fixed that here.